### PR TITLE
Feat/#26 validation rules

### DIFF
--- a/src/main/java/com/example/tracklybe/domain/habit/controller/HabitLogController.java
+++ b/src/main/java/com/example/tracklybe/domain/habit/controller/HabitLogController.java
@@ -4,6 +4,7 @@ import com.example.tracklybe.domain.habit.dto.request.HabitLogRequest;
 import com.example.tracklybe.domain.habit.dto.response.GetHabitLogResponse;
 import com.example.tracklybe.domain.habit.dto.response.HabitLogResponse;
 import com.example.tracklybe.domain.habit.service.HabitLogService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
@@ -28,7 +29,7 @@ public class HabitLogController {
     @PatchMapping("/{habitId}/logs/today")
     public ResponseEntity<HabitLogResponse> toggleToday(
             @PathVariable Long habitId,
-            @RequestBody HabitLogRequest habitLogRequest
+            @Valid @RequestBody HabitLogRequest habitLogRequest
     ) {
         HabitLogResponse habitLogResponse = habitLogService.toggleToday(habitId, habitLogRequest);
 

--- a/src/main/java/com/example/tracklybe/domain/habit/dto/request/CreateHabitRequest.java
+++ b/src/main/java/com/example/tracklybe/domain/habit/dto/request/CreateHabitRequest.java
@@ -3,6 +3,7 @@ package com.example.tracklybe.domain.habit.dto.request;
 import com.example.tracklybe.domain.habit.entity.HabitFrequency;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 
 import java.time.LocalDate;
@@ -12,11 +13,19 @@ import java.util.List;
 public class CreateHabitRequest {
 
     @NotBlank(message = "습관명을 입력해주세요.")
+    @Size(max = 50, message = "습관명은 50자 이하여야 합니다.")
     private String title;
+
+    @Size(max = 500, message = "설명은 500자 이하여야 합니다.")
     private String description;
+
     @NotNull(message = "습관 주기를 입력해주세요.")
     private HabitFrequency habitFrequency;
+
     private LocalDate startDate;
     private LocalDate endDate;
-    private List<String> tags;
+
+    @Size(max = 10, message = "태그는 최대 10개까지 등록할 수 있습니다.")
+    private List<@NotBlank(message = "태그는 공백일 수 없습니다.")
+            @Size(max = 30, message = "태그명은 30자 이하여야 합니다.") String> tags;
 }

--- a/src/main/java/com/example/tracklybe/domain/habit/dto/request/HabitLogRequest.java
+++ b/src/main/java/com/example/tracklybe/domain/habit/dto/request/HabitLogRequest.java
@@ -3,6 +3,7 @@ package com.example.tracklybe.domain.habit.dto.request;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import jakarta.validation.constraints.Size;
 
 @Getter
 @NoArgsConstructor
@@ -10,5 +11,7 @@ import lombok.NoArgsConstructor;
 public class HabitLogRequest {
 
     private boolean completed;
+
+    @Size(max = 500, message = "노트는 500자 이하여야 합니다.")
     private String note;
 }

--- a/src/main/java/com/example/tracklybe/domain/habit/dto/request/UpdateHabitRequest.java
+++ b/src/main/java/com/example/tracklybe/domain/habit/dto/request/UpdateHabitRequest.java
@@ -3,6 +3,7 @@ package com.example.tracklybe.domain.habit.dto.request;
 import com.example.tracklybe.domain.habit.entity.HabitFrequency;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 
 import java.time.LocalDate;
@@ -12,11 +13,19 @@ import java.util.List;
 public class UpdateHabitRequest {
 
     @NotBlank(message = "습관명을 입력해주세요.")
+    @Size(max = 50, message = "습관명은 50자 이하여야 합니다.")
     private String title;
+
+    @Size(max = 500, message = "설명은 500자 이하여야 합니다.")
     private String description;
+
     @NotNull(message = "습관 주기를 입력해주세요.")
     private HabitFrequency habitFrequency;
+
     private LocalDate startDate;
     private LocalDate endDate;
-    private List<String> tags;
+
+    @Size(max = 10, message = "태그는 최대 10개까지 등록할 수 있습니다.")
+    private List<@NotBlank(message = "태그는 공백일 수 없습니다.")
+            @Size(max = 30, message = "태그명은 30자 이하여야 합니다.") String> tags;
 }

--- a/src/main/java/com/example/tracklybe/domain/habit/service/HabitServiceImpl.java
+++ b/src/main/java/com/example/tracklybe/domain/habit/service/HabitServiceImpl.java
@@ -11,10 +11,12 @@ import com.example.tracklybe.domain.habit.repository.HabitTagRepository;
 import com.example.tracklybe.domain.tag.entity.Tag;
 import com.example.tracklybe.domain.tag.service.TagService;
 import com.example.tracklybe.global.exception.HabitNotFoundException;
+import com.example.tracklybe.global.exception.InvalidRequestException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -32,6 +34,8 @@ public class HabitServiceImpl implements HabitService {
 
     @Override
     public CreateHabitResponse createHabit(CreateHabitRequest createHabitRequest) {
+        validateDateRange(createHabitRequest.getStartDate(), createHabitRequest.getEndDate());
+
         Habit habit = Habit.builder()
                 .title(createHabitRequest.getTitle())
                 .description(createHabitRequest.getDescription())
@@ -84,6 +88,7 @@ public class HabitServiceImpl implements HabitService {
     @Override
     public GetHabitResponse updateHabit(UpdateHabitRequest updateHabitRequest, Long habitId) {
         Habit habit = habitRepository.findById(habitId).orElseThrow(() -> new HabitNotFoundException(habitId));
+        validateDateRange(updateHabitRequest.getStartDate(), updateHabitRequest.getEndDate());
         habit.update(updateHabitRequest);
         updateTags(habitId, updateHabitRequest.getTags());
         Set<String> tags = habitTagRepository.findTagNamesByHabitId(habitId);
@@ -127,6 +132,12 @@ public class HabitServiceImpl implements HabitService {
                     .map(tag -> HabitTag.builder().habit(habit).tag(tag).build())
                     .toList();
             habitTagRepository.saveAll(links);
+        }
+    }
+
+    private void validateDateRange(LocalDate startDate, LocalDate endDate) {
+        if (startDate != null && endDate != null && startDate.isAfter(endDate)) {
+            throw new InvalidRequestException("시작일은 종료일보다 늦을 수 없습니다.");
         }
     }
 }

--- a/src/main/java/com/example/tracklybe/global/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/tracklybe/global/exception/handler/GlobalExceptionHandler.java
@@ -6,9 +6,15 @@ import com.example.tracklybe.global.exception.HabitLogNotFoundException;
 import com.example.tracklybe.global.exception.HabitNotFoundException;
 import com.example.tracklybe.global.exception.InvalidRequestException;
 import com.example.tracklybe.global.exception.enumeration.ErrorCode;
+import jakarta.validation.ConstraintViolationException;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.stream.Collectors;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -28,9 +34,34 @@ public class GlobalExceptionHandler {
         return buildErrorResponse(e.getErrorCode(), e.getMessage());
     }
 
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<Void>> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+        String detail = e.getBindingResult().getFieldErrors().stream()
+                .map(this::toFieldErrorMessage)
+                .collect(Collectors.joining(", "));
+        return buildErrorResponse(ErrorCode.INVALID_REQUEST, detail);
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<ApiResponse<Void>> handleConstraintViolationException(ConstraintViolationException e) {
+        String detail = e.getConstraintViolations().stream()
+                .map(violation -> violation.getPropertyPath() + ": " + violation.getMessage())
+                .collect(Collectors.joining(", "));
+        return buildErrorResponse(ErrorCode.INVALID_REQUEST, detail);
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ApiResponse<Void>> handleHttpMessageNotReadableException(HttpMessageNotReadableException e) {
+        return buildErrorResponse(ErrorCode.INVALID_REQUEST, "요청 본문 형식이 올바르지 않습니다.");
+    }
+
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiResponse<Void>> handleGeneralException(Exception ex) {
         return buildErrorResponse(ErrorCode.INTERNAL_SERVER_ERROR, "예기치 않은 오류가 발생했습니다.");
+    }
+
+    private String toFieldErrorMessage(FieldError fieldError) {
+        return fieldError.getField() + ": " + fieldError.getDefaultMessage();
     }
 
     private ResponseEntity<ApiResponse<Void>> buildErrorResponse(ErrorCode errorCode, String detailMessage) {

--- a/src/test/java/com/example/tracklybe/domain/habit/controller/HabitControllerValidationTest.java
+++ b/src/test/java/com/example/tracklybe/domain/habit/controller/HabitControllerValidationTest.java
@@ -1,0 +1,96 @@
+package com.example.tracklybe.domain.habit.controller;
+
+import com.example.tracklybe.domain.habit.service.HabitService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(HabitController.class)
+class HabitControllerValidationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private HabitService habitService;
+
+    @MockitoBean
+    private JpaMetamodelMappingContext jpaMetamodelMappingContext;
+
+    @Test
+    void createHabit_returnsBadRequest_whenTitleTooLong() throws Exception {
+        String requestBody = """
+                {
+                  \"title\": \"%s\",
+                  \"description\": \"desc\",
+                  \"habitFrequency\": \"DAILY\",
+                  \"tags\": [\"health\"]
+                }
+                """.formatted("a".repeat(51));
+
+        mockMvc.perform(post("/api/habits")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value("INVALID_REQUEST"))
+                .andExpect(jsonPath("$.error.detail", containsString("title")));
+
+        verify(habitService, never()).createHabit(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    void createHabit_returnsBadRequest_whenTagIsBlank() throws Exception {
+        String requestBody = """
+                {
+                  \"title\": \"Morning Run\",
+                  \"description\": \"desc\",
+                  \"habitFrequency\": \"DAILY\",
+                  \"tags\": [\"  \"]
+                }
+                """;
+
+        mockMvc.perform(post("/api/habits")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value("INVALID_REQUEST"))
+                .andExpect(jsonPath("$.error.detail", containsString("태그는 공백일 수 없습니다.")));
+
+        verify(habitService, never()).createHabit(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    void createHabit_returnsBadRequest_whenHabitFrequencyInvalid() throws Exception {
+        String requestBody = """
+                {
+                  \"title\": \"Morning Run\",
+                  \"description\": \"desc\",
+                  \"habitFrequency\": \"YEARLY\",
+                  \"tags\": [\"health\"]
+                }
+                """;
+
+        mockMvc.perform(post("/api/habits")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value("INVALID_REQUEST"))
+                .andExpect(jsonPath("$.error.detail").value("요청 본문 형식이 올바르지 않습니다."));
+
+        verify(habitService, never()).createHabit(org.mockito.ArgumentMatchers.any());
+    }
+}

--- a/src/test/java/com/example/tracklybe/domain/habit/controller/HabitLogControllerValidationTest.java
+++ b/src/test/java/com/example/tracklybe/domain/habit/controller/HabitLogControllerValidationTest.java
@@ -1,0 +1,50 @@
+package com.example.tracklybe.domain.habit.controller;
+
+import com.example.tracklybe.domain.habit.service.HabitLogService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(HabitLogController.class)
+class HabitLogControllerValidationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private HabitLogService habitLogService;
+
+    @MockitoBean
+    private JpaMetamodelMappingContext jpaMetamodelMappingContext;
+
+    @Test
+    void toggleToday_returnsBadRequest_whenNoteTooLong() throws Exception {
+        String requestBody = """
+                {
+                  \"completed\": true,
+                  \"note\": \"%s\"
+                }
+                """.formatted("n".repeat(501));
+
+        mockMvc.perform(patch("/api/habits/1/logs/today")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value("INVALID_REQUEST"))
+                .andExpect(jsonPath("$.error.detail", containsString("노트는 500자 이하여야 합니다.")));
+
+        verify(habitLogService, never()).toggleToday(org.mockito.ArgumentMatchers.anyLong(), org.mockito.ArgumentMatchers.any());
+    }
+}

--- a/src/test/java/com/example/tracklybe/domain/habit/service/HabitServiceImplTest.java
+++ b/src/test/java/com/example/tracklybe/domain/habit/service/HabitServiceImplTest.java
@@ -12,6 +12,7 @@ import com.example.tracklybe.domain.habit.repository.HabitTagRepository;
 import com.example.tracklybe.domain.tag.entity.Tag;
 import com.example.tracklybe.domain.tag.service.TagService;
 import com.example.tracklybe.global.exception.HabitNotFoundException;
+import com.example.tracklybe.global.exception.InvalidRequestException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -106,6 +107,24 @@ class HabitServiceImplTest {
     }
 
     @Test
+    void createHabit_throwsInvalidRequestException_whenStartDateAfterEndDate() {
+        CreateHabitRequest request = mockCreateRequest(
+                "Invalid",
+                null,
+                HabitFrequency.DAILY,
+                LocalDate.of(2026, 4, 2),
+                LocalDate.of(2026, 4, 1),
+                List.of("Tag")
+        );
+
+        assertThatThrownBy(() -> habitService.createHabit(request))
+                .isInstanceOf(InvalidRequestException.class)
+                .hasMessageContaining("시작일은 종료일보다 늦을 수 없습니다.");
+
+        verify(habitRepository, never()).save(any(Habit.class));
+    }
+
+    @Test
     void getHabit_returnsResponseWithTags() {
         Habit existing = habit(3L, "Stretch", "10 min", HabitFrequency.DAILY, null, null);
         when(habitRepository.findById(3L)).thenReturn(Optional.of(existing));
@@ -180,6 +199,27 @@ class HabitServiceImplTest {
         assertThat(result.getDescription()).isEqualTo("new desc");
         assertThat(result.getHabitFrequency()).isEqualTo(HabitFrequency.MONTHLY);
         assertThat(result.getTags()).containsExactly("UpdatedTag");
+
+        verify(tagService, never()).getOrCreateEntities(anyCollection());
+    }
+
+    @Test
+    void updateHabit_throwsInvalidRequestException_whenStartDateAfterEndDate() {
+        Habit existing = habit(6L, "Old", "desc", HabitFrequency.WEEKLY, null, null);
+        UpdateHabitRequest request = mockUpdateRequest(
+                "New",
+                "new desc",
+                HabitFrequency.MONTHLY,
+                LocalDate.of(2026, 5, 2),
+                LocalDate.of(2026, 5, 1),
+                List.of("Focus")
+        );
+
+        when(habitRepository.findById(6L)).thenReturn(Optional.of(existing));
+
+        assertThatThrownBy(() -> habitService.updateHabit(request, 6L))
+                .isInstanceOf(InvalidRequestException.class)
+                .hasMessageContaining("시작일은 종료일보다 늦을 수 없습니다.");
 
         verify(tagService, never()).getOrCreateEntities(anyCollection());
     }


### PR DESCRIPTION
## 📌 요청 검증 강화

### ✅ PR 설명

요청 검증 강화

### 🏗 작업 내용

- [ ] Habit DTO 요청 검증 제약 추가 및 HabitLog 요청 @Valid 적용
- [ ] Habit 생성, 수정 시 시작일, 종료일 도메인 검증 추가
- [ ] 검증 예외 응답 표준화 
- [ ] 요청 검증 실패 컨트롤러 테스트 추가  

### 📸 테스트 결과 (선택)

> 기능을 테스트한 스크린샷이나 실행 결과를 첨부해주세요.

### 🔗 관련 이슈 (선택)

> close #26 

### 🚨 참고 사항 (선택)

> 리뷰어가 참고해야 할 사항이 있다면 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 습관 생성 및 수정 시 입력값 검증 강화 - 제목(최대 50자), 설명(최대 500자), 태그(최대 10개, 각 30자 이하) 길이 제한 추가
  * 시작 날짜와 종료 날짜 범위 검증 추가
  * 노트 길이 제한(최대 500자) 추가
  * 유효하지 않은 요청에 대한 상세한 에러 메시지 제공

<!-- end of auto-generated comment: release notes by coderabbit.ai -->