### PR TITLE
Feat/#28 auth access control

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,10 +26,14 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/main/java/com/example/tracklybe/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/tracklybe/domain/auth/controller/AuthController.java
@@ -2,6 +2,7 @@ package com.example.tracklybe.domain.auth.controller;
 
 import com.example.tracklybe.domain.auth.dto.LoginRequest;
 import com.example.tracklybe.domain.auth.dto.LoginResponse;
+import com.example.tracklybe.domain.auth.dto.RefreshTokenRequest;
 import com.example.tracklybe.domain.auth.service.AuthService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -21,5 +22,10 @@ public class AuthController {
     @PostMapping("/login")
     public ResponseEntity<LoginResponse> login(@Valid @RequestBody LoginRequest loginRequest) {
         return ResponseEntity.ok(authService.login(loginRequest));
+    }
+
+    @PostMapping("/refresh")
+    public ResponseEntity<LoginResponse> refresh(@Valid @RequestBody RefreshTokenRequest refreshTokenRequest) {
+        return ResponseEntity.ok(authService.refresh(refreshTokenRequest));
     }
 }

--- a/src/main/java/com/example/tracklybe/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/tracklybe/domain/auth/controller/AuthController.java
@@ -1,0 +1,25 @@
+package com.example.tracklybe.domain.auth.controller;
+
+import com.example.tracklybe.domain.auth.dto.LoginRequest;
+import com.example.tracklybe.domain.auth.dto.LoginResponse;
+import com.example.tracklybe.domain.auth.service.AuthService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/auth")
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/login")
+    public ResponseEntity<LoginResponse> login(@Valid @RequestBody LoginRequest loginRequest) {
+        return ResponseEntity.ok(authService.login(loginRequest));
+    }
+}

--- a/src/main/java/com/example/tracklybe/domain/auth/dto/LoginRequest.java
+++ b/src/main/java/com/example/tracklybe/domain/auth/dto/LoginRequest.java
@@ -1,0 +1,16 @@
+package com.example.tracklybe.domain.auth.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class LoginRequest {
+
+    @Email(message = "이메일 형식이 올바르지 않습니다.")
+    @NotBlank(message = "이메일을 입력해주세요.")
+    private String email;
+
+    @NotBlank(message = "비밀번호를 입력해주세요.")
+    private String password;
+}

--- a/src/main/java/com/example/tracklybe/domain/auth/dto/LoginResponse.java
+++ b/src/main/java/com/example/tracklybe/domain/auth/dto/LoginResponse.java
@@ -1,0 +1,12 @@
+package com.example.tracklybe.domain.auth.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class LoginResponse {
+    private String accessToken;
+    private String tokenType;
+    private long expiresIn;
+}

--- a/src/main/java/com/example/tracklybe/domain/auth/dto/LoginResponse.java
+++ b/src/main/java/com/example/tracklybe/domain/auth/dto/LoginResponse.java
@@ -7,6 +7,8 @@ import lombok.Getter;
 @Builder
 public class LoginResponse {
     private String accessToken;
+    private String refreshToken;
     private String tokenType;
-    private long expiresIn;
+    private long accessTokenExpiresIn;
+    private long refreshTokenExpiresIn;
 }

--- a/src/main/java/com/example/tracklybe/domain/auth/dto/RefreshTokenRequest.java
+++ b/src/main/java/com/example/tracklybe/domain/auth/dto/RefreshTokenRequest.java
@@ -1,0 +1,11 @@
+package com.example.tracklybe.domain.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class RefreshTokenRequest {
+
+    @NotBlank(message = "refresh token을 입력해주세요.")
+    private String refreshToken;
+}

--- a/src/main/java/com/example/tracklybe/domain/auth/entity/RefreshToken.java
+++ b/src/main/java/com/example/tracklybe/domain/auth/entity/RefreshToken.java
@@ -1,0 +1,51 @@
+package com.example.tracklybe.domain.auth.entity;
+
+import com.example.tracklybe.domain.common.entity.Timestamped;
+import com.example.tracklybe.domain.user.entity.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "refresh_tokens")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RefreshToken extends Timestamped {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long refreshTokenId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false, unique = true)
+    private User user;
+
+    @Column(nullable = false, unique = true, length = 512)
+    private String token;
+
+    @Column(nullable = false)
+    private LocalDateTime expiresAt;
+
+    public void rotate(String token, LocalDateTime expiresAt) {
+        this.token = token;
+        this.expiresAt = expiresAt;
+    }
+
+    public boolean isExpired(LocalDateTime now) {
+        return expiresAt.isBefore(now);
+    }
+}

--- a/src/main/java/com/example/tracklybe/domain/auth/entity/RefreshToken.java
+++ b/src/main/java/com/example/tracklybe/domain/auth/entity/RefreshToken.java
@@ -35,8 +35,8 @@ public class RefreshToken extends Timestamped {
     @JoinColumn(name = "user_id", nullable = false, unique = true)
     private User user;
 
-    @Column(nullable = false, unique = true, length = 512)
-    private String token;
+    @Column(name = "token_hash", nullable = false, unique = true, length = 64)
+    private String tokenHash;
 
     @Column(nullable = false)
     private LocalDateTime expiresAt;
@@ -44,8 +44,8 @@ public class RefreshToken extends Timestamped {
     @Version
     private Long version;
 
-    public void rotate(String token, LocalDateTime expiresAt) {
-        this.token = token;
+    public void rotate(String tokenHash, LocalDateTime expiresAt) {
+        this.tokenHash = tokenHash;
         this.expiresAt = expiresAt;
     }
 

--- a/src/main/java/com/example/tracklybe/domain/auth/entity/RefreshToken.java
+++ b/src/main/java/com/example/tracklybe/domain/auth/entity/RefreshToken.java
@@ -11,6 +11,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.Version;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -39,6 +40,9 @@ public class RefreshToken extends Timestamped {
 
     @Column(nullable = false)
     private LocalDateTime expiresAt;
+
+    @Version
+    private Long version;
 
     public void rotate(String token, LocalDateTime expiresAt) {
         this.token = token;

--- a/src/main/java/com/example/tracklybe/domain/auth/repository/JpaRefreshTokenStore.java
+++ b/src/main/java/com/example/tracklybe/domain/auth/repository/JpaRefreshTokenStore.java
@@ -1,0 +1,29 @@
+package com.example.tracklybe.domain.auth.repository;
+
+import com.example.tracklybe.domain.auth.entity.RefreshToken;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class JpaRefreshTokenStore implements RefreshTokenStore {
+
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    @Override
+    public Optional<RefreshToken> findByToken(String token) {
+        return refreshTokenRepository.findByToken(token);
+    }
+
+    @Override
+    public Optional<RefreshToken> findByUserId(Long userId) {
+        return refreshTokenRepository.findByUserUserId(userId);
+    }
+
+    @Override
+    public RefreshToken save(RefreshToken refreshToken) {
+        return refreshTokenRepository.save(refreshToken);
+    }
+}

--- a/src/main/java/com/example/tracklybe/domain/auth/repository/JpaRefreshTokenStore.java
+++ b/src/main/java/com/example/tracklybe/domain/auth/repository/JpaRefreshTokenStore.java
@@ -13,8 +13,8 @@ public class JpaRefreshTokenStore implements RefreshTokenStore {
     private final RefreshTokenRepository refreshTokenRepository;
 
     @Override
-    public Optional<RefreshToken> findByToken(String token) {
-        return refreshTokenRepository.findByToken(token);
+    public Optional<RefreshToken> findByTokenHash(String tokenHash) {
+        return refreshTokenRepository.findByTokenHash(tokenHash);
     }
 
     @Override

--- a/src/main/java/com/example/tracklybe/domain/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/example/tracklybe/domain/auth/repository/RefreshTokenRepository.java
@@ -6,6 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
-    Optional<RefreshToken> findByToken(String token);
+    Optional<RefreshToken> findByTokenHash(String tokenHash);
     Optional<RefreshToken> findByUserUserId(Long userId);
 }

--- a/src/main/java/com/example/tracklybe/domain/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/example/tracklybe/domain/auth/repository/RefreshTokenRepository.java
@@ -1,0 +1,11 @@
+package com.example.tracklybe.domain.auth.repository;
+
+import com.example.tracklybe.domain.auth.entity.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+    Optional<RefreshToken> findByToken(String token);
+    Optional<RefreshToken> findByUserUserId(Long userId);
+}

--- a/src/main/java/com/example/tracklybe/domain/auth/repository/RefreshTokenStore.java
+++ b/src/main/java/com/example/tracklybe/domain/auth/repository/RefreshTokenStore.java
@@ -1,0 +1,11 @@
+package com.example.tracklybe.domain.auth.repository;
+
+import com.example.tracklybe.domain.auth.entity.RefreshToken;
+
+import java.util.Optional;
+
+public interface RefreshTokenStore {
+    Optional<RefreshToken> findByToken(String token);
+    Optional<RefreshToken> findByUserId(Long userId);
+    RefreshToken save(RefreshToken refreshToken);
+}

--- a/src/main/java/com/example/tracklybe/domain/auth/repository/RefreshTokenStore.java
+++ b/src/main/java/com/example/tracklybe/domain/auth/repository/RefreshTokenStore.java
@@ -5,7 +5,7 @@ import com.example.tracklybe.domain.auth.entity.RefreshToken;
 import java.util.Optional;
 
 public interface RefreshTokenStore {
-    Optional<RefreshToken> findByToken(String token);
+    Optional<RefreshToken> findByTokenHash(String tokenHash);
     Optional<RefreshToken> findByUserId(Long userId);
     RefreshToken save(RefreshToken refreshToken);
 }

--- a/src/main/java/com/example/tracklybe/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/tracklybe/domain/auth/service/AuthService.java
@@ -2,7 +2,9 @@ package com.example.tracklybe.domain.auth.service;
 
 import com.example.tracklybe.domain.auth.dto.LoginRequest;
 import com.example.tracklybe.domain.auth.dto.LoginResponse;
+import com.example.tracklybe.domain.auth.dto.RefreshTokenRequest;
 
 public interface AuthService {
     LoginResponse login(LoginRequest loginRequest);
+    LoginResponse refresh(RefreshTokenRequest refreshTokenRequest);
 }

--- a/src/main/java/com/example/tracklybe/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/tracklybe/domain/auth/service/AuthService.java
@@ -1,0 +1,8 @@
+package com.example.tracklybe.domain.auth.service;
+
+import com.example.tracklybe.domain.auth.dto.LoginRequest;
+import com.example.tracklybe.domain.auth.dto.LoginResponse;
+
+public interface AuthService {
+    LoginResponse login(LoginRequest loginRequest);
+}

--- a/src/main/java/com/example/tracklybe/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/example/tracklybe/domain/auth/service/AuthServiceImpl.java
@@ -1,0 +1,39 @@
+package com.example.tracklybe.domain.auth.service;
+
+import com.example.tracklybe.domain.auth.dto.LoginRequest;
+import com.example.tracklybe.domain.auth.dto.LoginResponse;
+import com.example.tracklybe.domain.user.entity.User;
+import com.example.tracklybe.domain.user.repository.UserRepository;
+import com.example.tracklybe.global.exception.UnauthorizedException;
+import com.example.tracklybe.global.security.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AuthServiceImpl implements AuthService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    public LoginResponse login(LoginRequest loginRequest) {
+        User user = userRepository.findByEmail(loginRequest.getEmail())
+                .orElseThrow(() -> new UnauthorizedException("이메일 또는 비밀번호가 올바르지 않습니다."));
+
+        if (!passwordEncoder.matches(loginRequest.getPassword(), user.getPassword())) {
+            throw new UnauthorizedException("이메일 또는 비밀번호가 올바르지 않습니다.");
+        }
+
+        String accessToken = jwtTokenProvider.generateAccessToken(user);
+        return LoginResponse.builder()
+                .accessToken(accessToken)
+                .tokenType("Bearer")
+                .expiresIn(jwtTokenProvider.getAccessTokenValiditySeconds())
+                .build();
+    }
+}

--- a/src/main/java/com/example/tracklybe/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/example/tracklybe/domain/auth/service/AuthServiceImpl.java
@@ -2,6 +2,9 @@ package com.example.tracklybe.domain.auth.service;
 
 import com.example.tracklybe.domain.auth.dto.LoginRequest;
 import com.example.tracklybe.domain.auth.dto.LoginResponse;
+import com.example.tracklybe.domain.auth.dto.RefreshTokenRequest;
+import com.example.tracklybe.domain.auth.entity.RefreshToken;
+import com.example.tracklybe.domain.auth.repository.RefreshTokenStore;
 import com.example.tracklybe.domain.user.entity.User;
 import com.example.tracklybe.domain.user.repository.UserRepository;
 import com.example.tracklybe.global.exception.UnauthorizedException;
@@ -11,12 +14,15 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
+@Transactional
 public class AuthServiceImpl implements AuthService {
 
     private final UserRepository userRepository;
+    private final RefreshTokenStore refreshTokenStore;
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
 
@@ -29,11 +35,55 @@ public class AuthServiceImpl implements AuthService {
             throw new UnauthorizedException("이메일 또는 비밀번호가 올바르지 않습니다.");
         }
 
+        return issueTokens(user);
+    }
+
+    @Override
+    public LoginResponse refresh(RefreshTokenRequest refreshTokenRequest) {
+        String rawRefreshToken = refreshTokenRequest.getRefreshToken();
+        if (!jwtTokenProvider.validateRefreshToken(rawRefreshToken)) {
+            throw new UnauthorizedException("유효하지 않은 refresh token입니다.");
+        }
+
+        RefreshToken savedToken = refreshTokenStore.findByToken(rawRefreshToken)
+                .orElseThrow(() -> new UnauthorizedException("유효하지 않은 refresh token입니다."));
+
+        if (savedToken.isExpired(LocalDateTime.now())) {
+            throw new UnauthorizedException("만료된 refresh token입니다.");
+        }
+
+        Long userIdFromToken = jwtTokenProvider.getUserId(rawRefreshToken);
+        if (!savedToken.getUser().getUserId().equals(userIdFromToken)) {
+            throw new UnauthorizedException("유효하지 않은 refresh token입니다.");
+        }
+
+        return issueTokens(savedToken.getUser());
+    }
+
+    private LoginResponse issueTokens(User user) {
         String accessToken = jwtTokenProvider.generateAccessToken(user);
+        String refreshToken = jwtTokenProvider.generateRefreshToken(user);
+
+        LocalDateTime refreshExpiresAt = jwtTokenProvider.getRefreshTokenExpiresAt();
+
+        RefreshToken tokenEntity = refreshTokenStore.findByUserId(user.getUserId())
+                .orElseGet(() -> RefreshToken.builder()
+                        .user(user)
+                        .token(refreshToken)
+                        .expiresAt(refreshExpiresAt)
+                        .build());
+
+        if (tokenEntity.getRefreshTokenId() != null) {
+            tokenEntity.rotate(refreshToken, refreshExpiresAt);
+        }
+        refreshTokenStore.save(tokenEntity);
+
         return LoginResponse.builder()
                 .accessToken(accessToken)
+                .refreshToken(refreshToken)
                 .tokenType("Bearer")
-                .expiresIn(jwtTokenProvider.getAccessTokenValiditySeconds())
+                .accessTokenExpiresIn(jwtTokenProvider.getAccessTokenValiditySeconds())
+                .refreshTokenExpiresIn(jwtTokenProvider.getRefreshTokenValiditySeconds())
                 .build();
     }
 }

--- a/src/main/java/com/example/tracklybe/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/example/tracklybe/domain/auth/service/AuthServiceImpl.java
@@ -10,6 +10,7 @@ import com.example.tracklybe.domain.user.repository.UserRepository;
 import com.example.tracklybe.global.exception.UnauthorizedException;
 import com.example.tracklybe.global.security.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -76,7 +77,11 @@ public class AuthServiceImpl implements AuthService {
         if (tokenEntity.getRefreshTokenId() != null) {
             tokenEntity.rotate(refreshToken, refreshExpiresAt);
         }
-        refreshTokenStore.save(tokenEntity);
+        try {
+            refreshTokenStore.save(tokenEntity);
+        } catch (OptimisticLockingFailureException e) {
+            throw new UnauthorizedException("동시에 갱신되어 refresh token이 무효화되었습니다. 다시 시도해주세요.");
+        }
 
         return LoginResponse.builder()
                 .accessToken(accessToken)

--- a/src/main/java/com/example/tracklybe/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/example/tracklybe/domain/auth/service/AuthServiceImpl.java
@@ -9,6 +9,7 @@ import com.example.tracklybe.domain.user.entity.User;
 import com.example.tracklybe.domain.user.repository.UserRepository;
 import com.example.tracklybe.global.exception.UnauthorizedException;
 import com.example.tracklybe.global.security.JwtTokenProvider;
+import com.example.tracklybe.global.security.RefreshTokenHasher;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -26,6 +27,7 @@ public class AuthServiceImpl implements AuthService {
     private final RefreshTokenStore refreshTokenStore;
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
+    private final RefreshTokenHasher refreshTokenHasher;
 
     @Override
     public LoginResponse login(LoginRequest loginRequest) {
@@ -46,7 +48,8 @@ public class AuthServiceImpl implements AuthService {
             throw new UnauthorizedException("유효하지 않은 refresh token입니다.");
         }
 
-        RefreshToken savedToken = refreshTokenStore.findByToken(rawRefreshToken)
+        String refreshTokenHash = refreshTokenHasher.hash(rawRefreshToken);
+        RefreshToken savedToken = refreshTokenStore.findByTokenHash(refreshTokenHash)
                 .orElseThrow(() -> new UnauthorizedException("유효하지 않은 refresh token입니다."));
 
         if (savedToken.isExpired(LocalDateTime.now())) {
@@ -64,18 +67,19 @@ public class AuthServiceImpl implements AuthService {
     private LoginResponse issueTokens(User user) {
         String accessToken = jwtTokenProvider.generateAccessToken(user);
         String refreshToken = jwtTokenProvider.generateRefreshToken(user);
+        String refreshTokenHash = refreshTokenHasher.hash(refreshToken);
 
         LocalDateTime refreshExpiresAt = jwtTokenProvider.getRefreshTokenExpiresAt();
 
         RefreshToken tokenEntity = refreshTokenStore.findByUserId(user.getUserId())
                 .orElseGet(() -> RefreshToken.builder()
                         .user(user)
-                        .token(refreshToken)
+                        .tokenHash(refreshTokenHash)
                         .expiresAt(refreshExpiresAt)
                         .build());
 
         if (tokenEntity.getRefreshTokenId() != null) {
-            tokenEntity.rotate(refreshToken, refreshExpiresAt);
+            tokenEntity.rotate(refreshTokenHash, refreshExpiresAt);
         }
         try {
             refreshTokenStore.save(tokenEntity);

--- a/src/main/java/com/example/tracklybe/domain/habit/entity/Habit.java
+++ b/src/main/java/com/example/tracklybe/domain/habit/entity/Habit.java
@@ -3,13 +3,17 @@ package com.example.tracklybe.domain.habit.entity;
 import com.example.tracklybe.domain.common.entity.Timestamped;
 import com.example.tracklybe.domain.habit.dto.request.UpdateHabitRequest;
 import com.example.tracklybe.domain.habit.dto.response.GetHabitResponse;
+import com.example.tracklybe.domain.user.entity.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -30,6 +34,10 @@ public class Habit extends Timestamped {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long habitId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User owner;
 
     @Column(nullable = false)
     private String title;

--- a/src/main/java/com/example/tracklybe/domain/habit/entity/Habit.java
+++ b/src/main/java/com/example/tracklybe/domain/habit/entity/Habit.java
@@ -35,8 +35,8 @@ public class Habit extends Timestamped {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long habitId;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id")
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
     private User owner;
 
     @Column(nullable = false)

--- a/src/main/java/com/example/tracklybe/domain/habit/entity/HabitLog.java
+++ b/src/main/java/com/example/tracklybe/domain/habit/entity/HabitLog.java
@@ -3,6 +3,7 @@ package com.example.tracklybe.domain.habit.entity;
 import com.example.tracklybe.domain.common.entity.Timestamped;
 import com.example.tracklybe.domain.habit.dto.request.HabitLogRequest;
 import com.example.tracklybe.domain.habit.dto.response.HabitLogResponse;
+import com.example.tracklybe.domain.user.entity.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -42,6 +43,10 @@ public class HabitLog extends Timestamped {
     @JoinColumn(name = "habit_id", nullable = false)
     private Habit habit;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User owner;
+
     private LocalDate date;
 
     @Column(nullable = false)
@@ -67,6 +72,7 @@ public class HabitLog extends Timestamped {
 
         return HabitLog.builder()
                 .habit(habit)
+                .owner(habit.getOwner())
                 .date(today)
                 .completed(false)
                 .completedAt(null)

--- a/src/main/java/com/example/tracklybe/domain/habit/entity/HabitLog.java
+++ b/src/main/java/com/example/tracklybe/domain/habit/entity/HabitLog.java
@@ -43,8 +43,8 @@ public class HabitLog extends Timestamped {
     @JoinColumn(name = "habit_id", nullable = false)
     private Habit habit;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id")
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
     private User owner;
 
     private LocalDate date;

--- a/src/main/java/com/example/tracklybe/domain/habit/repository/HabitLogRepository.java
+++ b/src/main/java/com/example/tracklybe/domain/habit/repository/HabitLogRepository.java
@@ -5,9 +5,11 @@ import com.example.tracklybe.domain.habit.entity.HabitLog;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 public interface HabitLogRepository extends JpaRepository<HabitLog,Long> {
 
     Optional<HabitLog> findByHabitAndDate(Habit habit, LocalDate date);
+    List<HabitLog> findAllByOwnerUserId(Long ownerUserId);
 }

--- a/src/main/java/com/example/tracklybe/domain/habit/repository/HabitRepository.java
+++ b/src/main/java/com/example/tracklybe/domain/habit/repository/HabitRepository.java
@@ -4,6 +4,11 @@ import com.example.tracklybe.domain.habit.entity.Habit;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+import java.util.Optional;
+
 @Repository
 public interface HabitRepository extends JpaRepository<Habit, Long> {
+    Optional<Habit> findByHabitIdAndOwnerUserId(Long habitId, Long ownerUserId);
+    List<Habit> findAllByOwnerUserId(Long ownerUserId);
 }

--- a/src/main/java/com/example/tracklybe/domain/habit/service/HabitLogServiceImpl.java
+++ b/src/main/java/com/example/tracklybe/domain/habit/service/HabitLogServiceImpl.java
@@ -7,8 +7,10 @@ import com.example.tracklybe.domain.habit.entity.Habit;
 import com.example.tracklybe.domain.habit.entity.HabitLog;
 import com.example.tracklybe.domain.habit.repository.HabitLogRepository;
 import com.example.tracklybe.domain.habit.repository.HabitRepository;
+import com.example.tracklybe.global.exception.ForbiddenException;
 import com.example.tracklybe.global.exception.HabitLogNotFoundException;
 import com.example.tracklybe.global.exception.HabitNotFoundException;
+import com.example.tracklybe.global.security.CurrentUserProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,11 +25,12 @@ public class HabitLogServiceImpl implements HabitLogService {
 
     private final HabitRepository habitRepository;
     private final HabitLogRepository habitLogRepository;
+    private final CurrentUserProvider currentUserProvider;
 
     @Override
     public HabitLogResponse toggleToday(Long habitId, HabitLogRequest habitLogRequest) {
-        Habit habit = habitRepository.findById(habitId)
-                .orElseThrow(() -> new HabitNotFoundException(habitId));
+        Long currentUserId = currentUserProvider.getCurrentUserId();
+        Habit habit = findOwnedHabitOrThrow(habitId, currentUserId);
 
         LocalDate today = LocalDate.now();
 
@@ -41,9 +44,8 @@ public class HabitLogServiceImpl implements HabitLogService {
 
     @Override
     public GetHabitLogResponse getHabitLogByDate(Long habitId, LocalDate date) {
-
-        Habit habit = habitRepository.findById(habitId)
-                .orElseThrow(() -> new HabitNotFoundException(habitId));
+        Long currentUserId = currentUserProvider.getCurrentUserId();
+        Habit habit = findOwnedHabitOrThrow(habitId, currentUserId);
 
         HabitLog habitLog = habitLogRepository.findByHabitAndDate(habit, date)
                 .orElseThrow(() -> new HabitLogNotFoundException(habit.getHabitId(), date));
@@ -53,19 +55,30 @@ public class HabitLogServiceImpl implements HabitLogService {
 
     @Override
     public List<HabitLogResponse> getAllHabitLogs() {
-        return habitLogRepository.findAll().stream()
+        Long currentUserId = currentUserProvider.getCurrentUserId();
+        return habitLogRepository.findAllByOwnerUserId(currentUserId).stream()
                 .map(HabitLog::toResponse)
                 .toList();
     }
 
     @Override
     public void deleteHabitLogByDate(Long habitId, LocalDate date) {
-        Habit habit = habitRepository.findById(habitId)
-                .orElseThrow(() -> new HabitNotFoundException(habitId));
+        Long currentUserId = currentUserProvider.getCurrentUserId();
+        Habit habit = findOwnedHabitOrThrow(habitId, currentUserId);
 
         HabitLog habitLog = habitLogRepository.findByHabitAndDate(habit, date)
                 .orElseThrow(() -> new HabitLogNotFoundException(habit.getHabitId(), date));
 
         habitLogRepository.delete(habitLog);
+    }
+
+    private Habit findOwnedHabitOrThrow(Long habitId, Long currentUserId) {
+        return habitRepository.findByHabitIdAndOwnerUserId(habitId, currentUserId)
+                .orElseGet(() -> {
+                    if (habitRepository.existsById(habitId)) {
+                        throw new ForbiddenException("해당 습관에 접근 권한이 없습니다.");
+                    }
+                    throw new HabitNotFoundException(habitId);
+                });
     }
 }

--- a/src/main/java/com/example/tracklybe/domain/habit/service/HabitServiceImpl.java
+++ b/src/main/java/com/example/tracklybe/domain/habit/service/HabitServiceImpl.java
@@ -10,8 +10,12 @@ import com.example.tracklybe.domain.habit.repository.HabitRepository;
 import com.example.tracklybe.domain.habit.repository.HabitTagRepository;
 import com.example.tracklybe.domain.tag.entity.Tag;
 import com.example.tracklybe.domain.tag.service.TagService;
+import com.example.tracklybe.domain.user.entity.User;
+import com.example.tracklybe.domain.user.repository.UserRepository;
+import com.example.tracklybe.global.exception.ForbiddenException;
 import com.example.tracklybe.global.exception.HabitNotFoundException;
 import com.example.tracklybe.global.exception.InvalidRequestException;
+import com.example.tracklybe.global.security.CurrentUserProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -31,12 +35,18 @@ public class HabitServiceImpl implements HabitService {
     private final HabitRepository habitRepository;
     private final HabitTagRepository habitTagRepository;
     private final TagService tagService;
+    private final UserRepository userRepository;
+    private final CurrentUserProvider currentUserProvider;
 
     @Override
     public CreateHabitResponse createHabit(CreateHabitRequest createHabitRequest) {
         validateDateRange(createHabitRequest.getStartDate(), createHabitRequest.getEndDate());
+        Long currentUserId = currentUserProvider.getCurrentUserId();
+        User owner = userRepository.findById(currentUserId)
+                .orElseThrow(() -> new InvalidRequestException("유효하지 않은 사용자입니다."));
 
         Habit habit = Habit.builder()
+                .owner(owner)
                 .title(createHabitRequest.getTitle())
                 .description(createHabitRequest.getDescription())
                 .habitFrequency(createHabitRequest.getHabitFrequency())
@@ -61,14 +71,16 @@ public class HabitServiceImpl implements HabitService {
 
     @Override
     public GetHabitResponse getHabit(Long habitId) {
-        Habit habit = habitRepository.findById(habitId).orElseThrow(() -> new HabitNotFoundException(habitId));
+        Long currentUserId = currentUserProvider.getCurrentUserId();
+        Habit habit = findOwnedHabitOrThrow(habitId, currentUserId);
         Set<String> tags = habitTagRepository.findTagNamesByHabitId(habitId);
         return habit.toResponse(tags);
     }
 
     @Override
     public List<GetHabitResponse> getAllHabits() {
-        List<Habit> habits = habitRepository.findAll();
+        Long currentUserId = currentUserProvider.getCurrentUserId();
+        List<Habit> habits = habitRepository.findAllByOwnerUserId(currentUserId);
         List<Long> habitIds = habits.stream().map(Habit::getHabitId).toList();
         if (habitIds.isEmpty()) {
             return List.of();
@@ -87,7 +99,8 @@ public class HabitServiceImpl implements HabitService {
 
     @Override
     public GetHabitResponse updateHabit(UpdateHabitRequest updateHabitRequest, Long habitId) {
-        Habit habit = habitRepository.findById(habitId).orElseThrow(() -> new HabitNotFoundException(habitId));
+        Long currentUserId = currentUserProvider.getCurrentUserId();
+        Habit habit = findOwnedHabitOrThrow(habitId, currentUserId);
         validateDateRange(updateHabitRequest.getStartDate(), updateHabitRequest.getEndDate());
         habit.update(updateHabitRequest);
         updateTags(habitId, updateHabitRequest.getTags());
@@ -97,7 +110,8 @@ public class HabitServiceImpl implements HabitService {
 
     @Override
     public void deleteHabit(Long habitId) {
-        Habit habit = habitRepository.findById(habitId).orElseThrow(() -> new HabitNotFoundException(habitId));
+        Long currentUserId = currentUserProvider.getCurrentUserId();
+        Habit habit = findOwnedHabitOrThrow(habitId, currentUserId);
         habitTagRepository.deleteByHabit(habit);
         habitRepository.delete(habit);
     }
@@ -105,9 +119,9 @@ public class HabitServiceImpl implements HabitService {
     @Override
     public void updateTags(Long habitId, List<String> requestedTagNames) {
         if (requestedTagNames == null) return;
+        Long currentUserId = currentUserProvider.getCurrentUserId();
 
-        Habit habit = habitRepository.findById(habitId)
-                .orElseThrow(() -> new HabitNotFoundException(habitId));
+        Habit habit = findOwnedHabitOrThrow(habitId, currentUserId);
 
         List<Tag> targetTags = tagService.getOrCreateEntities(requestedTagNames);
         Set<String> newTags = targetTags.stream()
@@ -139,5 +153,15 @@ public class HabitServiceImpl implements HabitService {
         if (startDate != null && endDate != null && startDate.isAfter(endDate)) {
             throw new InvalidRequestException("시작일은 종료일보다 늦을 수 없습니다.");
         }
+    }
+
+    private Habit findOwnedHabitOrThrow(Long habitId, Long currentUserId) {
+        return habitRepository.findByHabitIdAndOwnerUserId(habitId, currentUserId)
+                .orElseGet(() -> {
+                    if (habitRepository.existsById(habitId)) {
+                        throw new ForbiddenException("해당 습관에 접근 권한이 없습니다.");
+                    }
+                    throw new HabitNotFoundException(habitId);
+                });
     }
 }

--- a/src/main/java/com/example/tracklybe/domain/user/entity/User.java
+++ b/src/main/java/com/example/tracklybe/domain/user/entity/User.java
@@ -1,0 +1,32 @@
+package com.example.tracklybe.domain.user.entity;
+
+import com.example.tracklybe.domain.common.entity.Timestamped;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "users")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class User extends Timestamped {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long userId;
+
+    @Column(nullable = false, unique = true, length = 100)
+    private String email;
+
+    @Column(nullable = false, length = 50)
+    private String nickname;
+}

--- a/src/main/java/com/example/tracklybe/domain/user/entity/User.java
+++ b/src/main/java/com/example/tracklybe/domain/user/entity/User.java
@@ -27,6 +27,9 @@ public class User extends Timestamped {
     @Column(nullable = false, unique = true, length = 100)
     private String email;
 
+    @Column(nullable = false, length = 255)
+    private String password;
+
     @Column(nullable = false, length = 50)
     private String nickname;
 }

--- a/src/main/java/com/example/tracklybe/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/example/tracklybe/domain/user/repository/UserRepository.java
@@ -1,0 +1,10 @@
+package com.example.tracklybe.domain.user.repository;
+
+import com.example.tracklybe.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByEmail(String email);
+}

--- a/src/main/java/com/example/tracklybe/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/tracklybe/global/config/SecurityConfig.java
@@ -23,6 +23,8 @@ public class SecurityConfig {
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
                 .csrf(csrf -> csrf.disable())
+                .formLogin(form -> form.disable())
+                .httpBasic(basic -> basic.disable())
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/auth/login", "/api/auth/refresh").permitAll()

--- a/src/main/java/com/example/tracklybe/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/tracklybe/global/config/SecurityConfig.java
@@ -1,6 +1,8 @@
 package com.example.tracklybe.global.config;
 
 import com.example.tracklybe.global.security.JwtAuthenticationFilter;
+import com.example.tracklybe.global.security.handler.RestAccessDeniedHandler;
+import com.example.tracklybe.global.security.handler.RestAuthenticationEntryPoint;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -18,6 +20,8 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final RestAuthenticationEntryPoint restAuthenticationEntryPoint;
+    private final RestAccessDeniedHandler restAccessDeniedHandler;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -29,6 +33,10 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/auth/login", "/api/auth/refresh").permitAll()
                         .anyRequest().authenticated()
+                )
+                .exceptionHandling(ex -> ex
+                        .authenticationEntryPoint(restAuthenticationEntryPoint)
+                        .accessDeniedHandler(restAccessDeniedHandler)
                 )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 

--- a/src/main/java/com/example/tracklybe/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/tracklybe/global/config/SecurityConfig.java
@@ -25,7 +25,7 @@ public class SecurityConfig {
                 .csrf(csrf -> csrf.disable())
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/auth/login").permitAll()
+                        .requestMatchers("/api/auth/login", "/api/auth/refresh").permitAll()
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/example/tracklybe/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/tracklybe/global/config/SecurityConfig.java
@@ -1,0 +1,40 @@
+package com.example.tracklybe.global.config;
+
+import com.example.tracklybe.global.security.JwtAuthenticationFilter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable())
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/api/auth/login").permitAll()
+                        .anyRequest().authenticated()
+                )
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/example/tracklybe/global/exception/ForbiddenException.java
+++ b/src/main/java/com/example/tracklybe/global/exception/ForbiddenException.java
@@ -1,0 +1,15 @@
+package com.example.tracklybe.global.exception;
+
+import com.example.tracklybe.global.exception.enumeration.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class ForbiddenException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public ForbiddenException(String detailMessage) {
+        super(detailMessage);
+        this.errorCode = ErrorCode.FORBIDDEN;
+    }
+}

--- a/src/main/java/com/example/tracklybe/global/exception/UnauthorizedException.java
+++ b/src/main/java/com/example/tracklybe/global/exception/UnauthorizedException.java
@@ -1,0 +1,15 @@
+package com.example.tracklybe.global.exception;
+
+import com.example.tracklybe.global.exception.enumeration.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class UnauthorizedException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public UnauthorizedException(String detailMessage) {
+        super(detailMessage);
+        this.errorCode = ErrorCode.UNAUTHORIZED;
+    }
+}

--- a/src/main/java/com/example/tracklybe/global/exception/enumeration/ErrorCode.java
+++ b/src/main/java/com/example/tracklybe/global/exception/enumeration/ErrorCode.java
@@ -10,7 +10,8 @@ public enum ErrorCode {
 
     // 공통
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류가 발생했습니다."),
-    INVALID_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다.");
+    INVALID_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다.");
 
     private final HttpStatus status;
     private final String message;
@@ -28,4 +29,3 @@ public enum ErrorCode {
         return message;
     }
 }
-

--- a/src/main/java/com/example/tracklybe/global/exception/enumeration/ErrorCode.java
+++ b/src/main/java/com/example/tracklybe/global/exception/enumeration/ErrorCode.java
@@ -11,6 +11,7 @@ public enum ErrorCode {
     // 공통
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류가 발생했습니다."),
     INVALID_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
+    FORBIDDEN(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다.");
 
     private final HttpStatus status;

--- a/src/main/java/com/example/tracklybe/global/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/tracklybe/global/exception/handler/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import com.example.tracklybe.domain.common.dto.ApiResponse;
 import com.example.tracklybe.global.exception.HabitLogNotFoundException;
 import com.example.tracklybe.global.exception.HabitNotFoundException;
 import com.example.tracklybe.global.exception.InvalidRequestException;
+import com.example.tracklybe.global.exception.ForbiddenException;
 import com.example.tracklybe.global.exception.UnauthorizedException;
 import com.example.tracklybe.global.exception.enumeration.ErrorCode;
 import jakarta.validation.ConstraintViolationException;
@@ -37,6 +38,11 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(UnauthorizedException.class)
     public ResponseEntity<ApiResponse<Void>> handleUnauthorizedException(UnauthorizedException e) {
+        return buildErrorResponse(e.getErrorCode(), e.getMessage());
+    }
+
+    @ExceptionHandler(ForbiddenException.class)
+    public ResponseEntity<ApiResponse<Void>> handleForbiddenException(ForbiddenException e) {
         return buildErrorResponse(e.getErrorCode(), e.getMessage());
     }
 

--- a/src/main/java/com/example/tracklybe/global/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/tracklybe/global/exception/handler/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import com.example.tracklybe.domain.common.dto.ApiResponse;
 import com.example.tracklybe.global.exception.HabitLogNotFoundException;
 import com.example.tracklybe.global.exception.HabitNotFoundException;
 import com.example.tracklybe.global.exception.InvalidRequestException;
+import com.example.tracklybe.global.exception.UnauthorizedException;
 import com.example.tracklybe.global.exception.enumeration.ErrorCode;
 import jakarta.validation.ConstraintViolationException;
 import org.springframework.http.ResponseEntity;
@@ -31,6 +32,11 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(InvalidRequestException.class)
     public ResponseEntity<ApiResponse<Void>> handleInvalidRequestException(InvalidRequestException e) {
+        return buildErrorResponse(e.getErrorCode(), e.getMessage());
+    }
+
+    @ExceptionHandler(UnauthorizedException.class)
+    public ResponseEntity<ApiResponse<Void>> handleUnauthorizedException(UnauthorizedException e) {
         return buildErrorResponse(e.getErrorCode(), e.getMessage());
     }
 

--- a/src/main/java/com/example/tracklybe/global/security/AuthenticatedUser.java
+++ b/src/main/java/com/example/tracklybe/global/security/AuthenticatedUser.java
@@ -1,0 +1,4 @@
+package com.example.tracklybe.global.security;
+
+public record AuthenticatedUser(Long userId, String email) {
+}

--- a/src/main/java/com/example/tracklybe/global/security/CurrentUserProvider.java
+++ b/src/main/java/com/example/tracklybe/global/security/CurrentUserProvider.java
@@ -1,0 +1,18 @@
+package com.example.tracklybe.global.security;
+
+import com.example.tracklybe.global.exception.UnauthorizedException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CurrentUserProvider {
+
+    public Long getCurrentUserId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !(authentication.getPrincipal() instanceof AuthenticatedUser principal)) {
+            throw new UnauthorizedException("인증 정보가 없습니다.");
+        }
+        return principal.userId();
+    }
+}

--- a/src/main/java/com/example/tracklybe/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/tracklybe/global/security/JwtAuthenticationFilter.java
@@ -33,7 +33,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         if (header != null && header.startsWith(BEARER_PREFIX)
                 && SecurityContextHolder.getContext().getAuthentication() == null) {
             String token = header.substring(BEARER_PREFIX.length());
-            if (jwtTokenProvider.validateToken(token)) {
+            if (jwtTokenProvider.validateAccessToken(token)) {
                 Long userId = jwtTokenProvider.getUserId(token);
                 String email = jwtTokenProvider.getEmail(token);
                 AuthenticatedUser principal = new AuthenticatedUser(userId, email);

--- a/src/main/java/com/example/tracklybe/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/tracklybe/global/security/JwtAuthenticationFilter.java
@@ -1,0 +1,53 @@
+package com.example.tracklybe.global.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+
+        String header = request.getHeader(HttpHeaders.AUTHORIZATION);
+        if (header != null && header.startsWith(BEARER_PREFIX)
+                && SecurityContextHolder.getContext().getAuthentication() == null) {
+            String token = header.substring(BEARER_PREFIX.length());
+            if (jwtTokenProvider.validateToken(token)) {
+                Long userId = jwtTokenProvider.getUserId(token);
+                String email = jwtTokenProvider.getEmail(token);
+                AuthenticatedUser principal = new AuthenticatedUser(userId, email);
+                UsernamePasswordAuthenticationToken authentication =
+                        new UsernamePasswordAuthenticationToken(
+                                principal,
+                                null,
+                                List.of(new SimpleGrantedAuthority("ROLE_USER"))
+                        );
+                authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/example/tracklybe/global/security/JwtTokenProvider.java
+++ b/src/main/java/com/example/tracklybe/global/security/JwtTokenProvider.java
@@ -1,0 +1,77 @@
+package com.example.tracklybe.global.security;
+
+import com.example.tracklybe.domain.user.entity.User;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Date;
+
+@Component
+public class JwtTokenProvider {
+
+    @Value("${jwt.secret}")
+    private String secret;
+
+    @Value("${jwt.access-token-validity-seconds}")
+    private long accessTokenValiditySeconds;
+
+    private SecretKey secretKey;
+
+    @PostConstruct
+    void init() {
+        this.secretKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+    }
+
+    public String generateAccessToken(User user) {
+        Instant now = Instant.now();
+        Instant expiry = now.plusSeconds(accessTokenValiditySeconds);
+
+        return Jwts.builder()
+                .subject(user.getEmail())
+                .claim("uid", user.getUserId())
+                .issuedAt(Date.from(now))
+                .expiration(Date.from(expiry))
+                .signWith(secretKey)
+                .compact();
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            parseClaims(token);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    public Long getUserId(String token) {
+        Object uid = parseClaims(token).get("uid");
+        if (uid instanceof Number number) {
+            return number.longValue();
+        }
+        return Long.parseLong(String.valueOf(uid));
+    }
+
+    public String getEmail(String token) {
+        return parseClaims(token).getSubject();
+    }
+
+    public long getAccessTokenValiditySeconds() {
+        return accessTokenValiditySeconds;
+    }
+
+    private Claims parseClaims(String token) {
+        return Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+}

--- a/src/main/java/com/example/tracklybe/global/security/JwtTokenProvider.java
+++ b/src/main/java/com/example/tracklybe/global/security/JwtTokenProvider.java
@@ -11,16 +11,24 @@ import org.springframework.stereotype.Component;
 import javax.crypto.SecretKey;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
+import java.time.LocalDateTime;
 import java.util.Date;
 
 @Component
 public class JwtTokenProvider {
+
+    private static final String TOKEN_TYPE_CLAIM = "typ";
+    private static final String ACCESS_TOKEN_TYPE = "access";
+    private static final String REFRESH_TOKEN_TYPE = "refresh";
 
     @Value("${jwt.secret}")
     private String secret;
 
     @Value("${jwt.access-token-validity-seconds}")
     private long accessTokenValiditySeconds;
+
+    @Value("${jwt.refresh-token-validity-seconds}")
+    private long refreshTokenValiditySeconds;
 
     private SecretKey secretKey;
 
@@ -30,22 +38,47 @@ public class JwtTokenProvider {
     }
 
     public String generateAccessToken(User user) {
+        return generateToken(user, ACCESS_TOKEN_TYPE, accessTokenValiditySeconds);
+    }
+
+    public String generateRefreshToken(User user) {
+        return generateToken(user, REFRESH_TOKEN_TYPE, refreshTokenValiditySeconds);
+    }
+
+    public boolean validateAccessToken(String token) {
+        return validateTokenWithType(token, ACCESS_TOKEN_TYPE);
+    }
+
+    public boolean validateRefreshToken(String token) {
+        return validateTokenWithType(token, REFRESH_TOKEN_TYPE);
+    }
+
+    public long getRefreshTokenValiditySeconds() {
+        return refreshTokenValiditySeconds;
+    }
+
+    public LocalDateTime getRefreshTokenExpiresAt() {
+        return LocalDateTime.now().plusSeconds(refreshTokenValiditySeconds);
+    }
+
+    private String generateToken(User user, String tokenType, long validitySeconds) {
         Instant now = Instant.now();
-        Instant expiry = now.plusSeconds(accessTokenValiditySeconds);
+        Instant expiry = now.plusSeconds(validitySeconds);
 
         return Jwts.builder()
                 .subject(user.getEmail())
                 .claim("uid", user.getUserId())
+                .claim(TOKEN_TYPE_CLAIM, tokenType)
                 .issuedAt(Date.from(now))
                 .expiration(Date.from(expiry))
                 .signWith(secretKey)
                 .compact();
     }
 
-    public boolean validateToken(String token) {
+    private boolean validateTokenWithType(String token, String expectedTokenType) {
         try {
-            parseClaims(token);
-            return true;
+            Claims claims = parseClaims(token);
+            return expectedTokenType.equals(claims.get(TOKEN_TYPE_CLAIM, String.class));
         } catch (Exception e) {
             return false;
         }

--- a/src/main/java/com/example/tracklybe/global/security/RefreshTokenHasher.java
+++ b/src/main/java/com/example/tracklybe/global/security/RefreshTokenHasher.java
@@ -1,0 +1,37 @@
+package com.example.tracklybe.global.security;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+
+@Component
+public class RefreshTokenHasher {
+
+    private static final String HMAC_ALGORITHM = "HmacSHA256";
+
+    @Value("${jwt.refresh-token-hash-secret:${jwt.secret}}")
+    private String hashSecret;
+
+    public String hash(String rawToken) {
+        try {
+            Mac mac = Mac.getInstance(HMAC_ALGORITHM);
+            SecretKeySpec keySpec = new SecretKeySpec(hashSecret.getBytes(StandardCharsets.UTF_8), HMAC_ALGORITHM);
+            mac.init(keySpec);
+            byte[] digest = mac.doFinal(rawToken.getBytes(StandardCharsets.UTF_8));
+            return toHex(digest);
+        } catch (Exception e) {
+            throw new IllegalStateException("refresh token hash 생성에 실패했습니다.", e);
+        }
+    }
+
+    private String toHex(byte[] bytes) {
+        StringBuilder sb = new StringBuilder(bytes.length * 2);
+        for (byte b : bytes) {
+            sb.append(String.format("%02x", b));
+        }
+        return sb.toString();
+    }
+}

--- a/src/main/java/com/example/tracklybe/global/security/RefreshTokenHasher.java
+++ b/src/main/java/com/example/tracklybe/global/security/RefreshTokenHasher.java
@@ -12,7 +12,7 @@ public class RefreshTokenHasher {
 
     private static final String HMAC_ALGORITHM = "HmacSHA256";
 
-    @Value("${jwt.refresh-token-hash-secret:${jwt.secret}}")
+    @Value("${jwt.refresh-token-hash-secret}")
     private String hashSecret;
 
     public String hash(String rawToken) {

--- a/src/main/java/com/example/tracklybe/global/security/handler/RestAccessDeniedHandler.java
+++ b/src/main/java/com/example/tracklybe/global/security/handler/RestAccessDeniedHandler.java
@@ -1,0 +1,41 @@
+package com.example.tracklybe.global.security.handler;
+
+import com.example.tracklybe.domain.common.dto.ApiError;
+import com.example.tracklybe.domain.common.dto.ApiResponse;
+import com.example.tracklybe.global.exception.enumeration.ErrorCode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+@Component
+@RequiredArgsConstructor
+public class RestAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void handle(HttpServletRequest request,
+                       HttpServletResponse response,
+                       AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        writeError(response, ErrorCode.FORBIDDEN, "해당 리소스에 접근할 권한이 없습니다.");
+    }
+
+    private void writeError(HttpServletResponse response, ErrorCode errorCode, String detail) throws IOException {
+        response.setStatus(errorCode.getStatus().value());
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+
+        ApiError apiError = ApiError.of(errorCode, detail);
+        ApiResponse<Void> body = ApiResponse.fail(apiError);
+        response.getWriter().write(objectMapper.writeValueAsString(body));
+    }
+}

--- a/src/main/java/com/example/tracklybe/global/security/handler/RestAuthenticationEntryPoint.java
+++ b/src/main/java/com/example/tracklybe/global/security/handler/RestAuthenticationEntryPoint.java
@@ -1,0 +1,41 @@
+package com.example.tracklybe.global.security.handler;
+
+import com.example.tracklybe.domain.common.dto.ApiError;
+import com.example.tracklybe.domain.common.dto.ApiResponse;
+import com.example.tracklybe.global.exception.enumeration.ErrorCode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+@Component
+@RequiredArgsConstructor
+public class RestAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(HttpServletRequest request,
+                         HttpServletResponse response,
+                         AuthenticationException authException) throws IOException, ServletException {
+        writeError(response, ErrorCode.UNAUTHORIZED, "인증이 필요하거나 토큰이 유효하지 않습니다.");
+    }
+
+    private void writeError(HttpServletResponse response, ErrorCode errorCode, String detail) throws IOException {
+        response.setStatus(errorCode.getStatus().value());
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+
+        ApiError apiError = ApiError.of(errorCode, detail);
+        ApiResponse<Void> body = ApiResponse.fail(apiError);
+        response.getWriter().write(objectMapper.writeValueAsString(body));
+    }
+}

--- a/src/test/java/com/example/tracklybe/domain/habit/controller/HabitControllerValidationTest.java
+++ b/src/test/java/com/example/tracklybe/domain/habit/controller/HabitControllerValidationTest.java
@@ -1,6 +1,7 @@
 package com.example.tracklybe.domain.habit.controller;
 
 import com.example.tracklybe.domain.habit.service.HabitService;
+import com.example.tracklybe.global.exception.ForbiddenException;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -13,7 +14,9 @@ import org.springframework.test.web.servlet.MockMvc;
 import static org.hamcrest.Matchers.containsString;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -94,5 +97,17 @@ class HabitControllerValidationTest {
                 .andExpect(jsonPath("$.error.detail").value("요청 본문 형식이 올바르지 않습니다."));
 
         verify(habitService, never()).createHabit(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    void getHabit_returnsForbidden_whenHabitOwnedByAnotherUser() throws Exception {
+        when(habitService.getHabit(99L))
+                .thenThrow(new ForbiddenException("해당 습관에 접근 권한이 없습니다."));
+
+        mockMvc.perform(get("/api/habits/99"))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value("FORBIDDEN"))
+                .andExpect(jsonPath("$.error.detail").value("해당 습관에 접근 권한이 없습니다."));
     }
 }

--- a/src/test/java/com/example/tracklybe/domain/habit/controller/HabitControllerValidationTest.java
+++ b/src/test/java/com/example/tracklybe/domain/habit/controller/HabitControllerValidationTest.java
@@ -3,6 +3,7 @@ package com.example.tracklybe.domain.habit.controller;
 import com.example.tracklybe.domain.habit.service.HabitService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.MediaType;
@@ -17,6 +18,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(HabitController.class)
+@AutoConfigureMockMvc(addFilters = false)
 class HabitControllerValidationTest {
 
     @Autowired

--- a/src/test/java/com/example/tracklybe/domain/habit/controller/HabitLogControllerValidationTest.java
+++ b/src/test/java/com/example/tracklybe/domain/habit/controller/HabitLogControllerValidationTest.java
@@ -3,6 +3,7 @@ package com.example.tracklybe.domain.habit.controller;
 import com.example.tracklybe.domain.habit.service.HabitLogService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.MediaType;
@@ -17,6 +18,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(HabitLogController.class)
+@AutoConfigureMockMvc(addFilters = false)
 class HabitLogControllerValidationTest {
 
     @Autowired

--- a/src/test/java/com/example/tracklybe/domain/habit/controller/HabitLogControllerValidationTest.java
+++ b/src/test/java/com/example/tracklybe/domain/habit/controller/HabitLogControllerValidationTest.java
@@ -1,6 +1,7 @@
 package com.example.tracklybe.domain.habit.controller;
 
 import com.example.tracklybe.domain.habit.service.HabitLogService;
+import com.example.tracklybe.global.exception.ForbiddenException;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -13,6 +14,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import static org.hamcrest.Matchers.containsString;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -48,5 +50,26 @@ class HabitLogControllerValidationTest {
                 .andExpect(jsonPath("$.error.detail", containsString("노트는 500자 이하여야 합니다.")));
 
         verify(habitLogService, never()).toggleToday(org.mockito.ArgumentMatchers.anyLong(), org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    void toggleToday_returnsForbidden_whenHabitOwnedByAnotherUser() throws Exception {
+        when(habitLogService.toggleToday(org.mockito.ArgumentMatchers.eq(99L), org.mockito.ArgumentMatchers.any()))
+                .thenThrow(new ForbiddenException("해당 습관에 접근 권한이 없습니다."));
+
+        String requestBody = """
+                {
+                  "completed": true,
+                  "note": "done"
+                }
+                """;
+
+        mockMvc.perform(patch("/api/habits/99/logs/today")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value("FORBIDDEN"))
+                .andExpect(jsonPath("$.error.detail").value("해당 습관에 접근 권한이 없습니다."));
     }
 }

--- a/src/test/java/com/example/tracklybe/domain/habit/service/HabitLogServiceImplTest.java
+++ b/src/test/java/com/example/tracklybe/domain/habit/service/HabitLogServiceImplTest.java
@@ -10,6 +10,7 @@ import com.example.tracklybe.domain.habit.repository.HabitLogRepository;
 import com.example.tracklybe.domain.habit.repository.HabitRepository;
 import com.example.tracklybe.global.exception.HabitLogNotFoundException;
 import com.example.tracklybe.global.exception.HabitNotFoundException;
+import com.example.tracklybe.global.security.CurrentUserProvider;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -37,6 +38,9 @@ class HabitLogServiceImplTest {
     @Mock
     private HabitLogRepository habitLogRepository;
 
+    @Mock
+    private CurrentUserProvider currentUserProvider;
+
     @InjectMocks
     private HabitLogServiceImpl habitLogService;
 
@@ -46,7 +50,8 @@ class HabitLogServiceImplTest {
         HabitLog existingLog = habitLog(10L, habit, LocalDate.of(2026, 3, 30), false, null, null);
         HabitLogRequest request = new HabitLogRequest(true, "done");
 
-        when(habitRepository.findById(1L)).thenReturn(Optional.of(habit));
+        when(currentUserProvider.getCurrentUserId()).thenReturn(100L);
+        when(habitRepository.findByHabitIdAndOwnerUserId(1L, 100L)).thenReturn(Optional.of(habit));
         when(habitLogRepository.findByHabitAndDate(any(Habit.class), any(LocalDate.class))).thenReturn(Optional.of(existingLog));
         when(habitLogRepository.save(existingLog)).thenReturn(existingLog);
 
@@ -66,7 +71,8 @@ class HabitLogServiceImplTest {
         Habit habit = habit(2L, "Read");
         HabitLogRequest request = new HabitLogRequest(false, "later");
 
-        when(habitRepository.findById(2L)).thenReturn(Optional.of(habit));
+        when(currentUserProvider.getCurrentUserId()).thenReturn(100L);
+        when(habitRepository.findByHabitIdAndOwnerUserId(2L, 100L)).thenReturn(Optional.of(habit));
         when(habitLogRepository.findByHabitAndDate(any(Habit.class), any(LocalDate.class))).thenReturn(Optional.empty());
         when(habitLogRepository.save(any(HabitLog.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
@@ -82,7 +88,8 @@ class HabitLogServiceImplTest {
 
     @Test
     void toggleToday_throwsHabitNotFoundException_whenHabitMissing() {
-        when(habitRepository.findById(99L)).thenReturn(Optional.empty());
+        when(currentUserProvider.getCurrentUserId()).thenReturn(100L);
+        when(habitRepository.findByHabitIdAndOwnerUserId(99L, 100L)).thenReturn(Optional.empty());
         HabitLogRequest request = new HabitLogRequest(true, null);
 
         assertThatThrownBy(() -> habitLogService.toggleToday(99L, request))
@@ -98,7 +105,8 @@ class HabitLogServiceImplTest {
         LocalDate date = LocalDate.of(2026, 3, 30);
         HabitLog log = habitLog(30L, habit, date, true, LocalTime.of(8, 30), "ok");
 
-        when(habitRepository.findById(3L)).thenReturn(Optional.of(habit));
+        when(currentUserProvider.getCurrentUserId()).thenReturn(100L);
+        when(habitRepository.findByHabitIdAndOwnerUserId(3L, 100L)).thenReturn(Optional.of(habit));
         when(habitLogRepository.findByHabitAndDate(habit, date)).thenReturn(Optional.of(log));
 
         GetHabitLogResponse response = habitLogService.getHabitLogByDate(3L, date);
@@ -113,7 +121,8 @@ class HabitLogServiceImplTest {
     @Test
     void getHabitLogByDate_throwsHabitNotFoundException_whenHabitMissing() {
         LocalDate date = LocalDate.of(2026, 3, 30);
-        when(habitRepository.findById(404L)).thenReturn(Optional.empty());
+        when(currentUserProvider.getCurrentUserId()).thenReturn(100L);
+        when(habitRepository.findByHabitIdAndOwnerUserId(404L, 100L)).thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> habitLogService.getHabitLogByDate(404L, date))
                 .isInstanceOf(HabitNotFoundException.class);
@@ -124,7 +133,8 @@ class HabitLogServiceImplTest {
         Habit habit = habit(4L, "Meditate");
         LocalDate date = LocalDate.of(2026, 3, 30);
 
-        when(habitRepository.findById(4L)).thenReturn(Optional.of(habit));
+        when(currentUserProvider.getCurrentUserId()).thenReturn(100L);
+        when(habitRepository.findByHabitIdAndOwnerUserId(4L, 100L)).thenReturn(Optional.of(habit));
         when(habitLogRepository.findByHabitAndDate(habit, date)).thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> habitLogService.getHabitLogByDate(4L, date))
@@ -141,7 +151,8 @@ class HabitLogServiceImplTest {
         HabitLog firstLog = habitLog(50L, firstHabit, LocalDate.of(2026, 3, 29), true, LocalTime.of(6, 0), "good");
         HabitLog secondLog = habitLog(60L, secondHabit, LocalDate.of(2026, 3, 29), false, null, null);
 
-        when(habitLogRepository.findAll()).thenReturn(List.of(firstLog, secondLog));
+        when(currentUserProvider.getCurrentUserId()).thenReturn(100L);
+        when(habitLogRepository.findAllByOwnerUserId(100L)).thenReturn(List.of(firstLog, secondLog));
 
         List<HabitLogResponse> result = habitLogService.getAllHabitLogs();
 
@@ -158,7 +169,8 @@ class HabitLogServiceImplTest {
         LocalDate date = LocalDate.of(2026, 3, 28);
         HabitLog log = habitLog(70L, habit, date, true, LocalTime.of(22, 0), null);
 
-        when(habitRepository.findById(7L)).thenReturn(Optional.of(habit));
+        when(currentUserProvider.getCurrentUserId()).thenReturn(100L);
+        when(habitRepository.findByHabitIdAndOwnerUserId(7L, 100L)).thenReturn(Optional.of(habit));
         when(habitLogRepository.findByHabitAndDate(habit, date)).thenReturn(Optional.of(log));
 
         habitLogService.deleteHabitLogByDate(7L, date);
@@ -171,7 +183,8 @@ class HabitLogServiceImplTest {
         Habit habit = habit(8L, "Journal");
         LocalDate date = LocalDate.of(2026, 3, 28);
 
-        when(habitRepository.findById(8L)).thenReturn(Optional.of(habit));
+        when(currentUserProvider.getCurrentUserId()).thenReturn(100L);
+        when(habitRepository.findByHabitIdAndOwnerUserId(8L, 100L)).thenReturn(Optional.of(habit));
         when(habitLogRepository.findByHabitAndDate(habit, date)).thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> habitLogService.deleteHabitLogByDate(8L, date))

--- a/src/test/java/com/example/tracklybe/domain/habit/service/HabitServiceImplTest.java
+++ b/src/test/java/com/example/tracklybe/domain/habit/service/HabitServiceImplTest.java
@@ -11,8 +11,11 @@ import com.example.tracklybe.domain.habit.repository.HabitRepository;
 import com.example.tracklybe.domain.habit.repository.HabitTagRepository;
 import com.example.tracklybe.domain.tag.entity.Tag;
 import com.example.tracklybe.domain.tag.service.TagService;
+import com.example.tracklybe.domain.user.entity.User;
+import com.example.tracklybe.domain.user.repository.UserRepository;
 import com.example.tracklybe.global.exception.HabitNotFoundException;
 import com.example.tracklybe.global.exception.InvalidRequestException;
+import com.example.tracklybe.global.security.CurrentUserProvider;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -48,6 +51,12 @@ class HabitServiceImplTest {
     @Mock
     private TagService tagService;
 
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private CurrentUserProvider currentUserProvider;
+
     @InjectMocks
     private HabitServiceImpl habitService;
 
@@ -66,7 +75,10 @@ class HabitServiceImplTest {
                 LocalDate.of(2026, 3, 1), LocalDate.of(2026, 12, 31));
         Tag health = tag(10L, "Health", "health");
         Tag routine = tag(11L, "Routine", "routine");
+        User owner = user(100L, "owner@test.com");
 
+        when(currentUserProvider.getCurrentUserId()).thenReturn(100L);
+        when(userRepository.findById(100L)).thenReturn(Optional.of(owner));
         when(habitRepository.save(any(Habit.class))).thenReturn(savedHabit);
         when(tagService.getOrCreateEntities(List.of("Health", "Routine"))).thenReturn(List.of(health, routine));
 
@@ -96,7 +108,10 @@ class HabitServiceImplTest {
         );
 
         Habit savedHabit = habit(2L, "Read", null, HabitFrequency.DAILY, null, null);
+        User owner = user(100L, "owner@test.com");
 
+        when(currentUserProvider.getCurrentUserId()).thenReturn(100L);
+        when(userRepository.findById(100L)).thenReturn(Optional.of(owner));
         when(habitRepository.save(any(Habit.class))).thenReturn(savedHabit);
         when(tagService.getOrCreateEntities(List.of("Read"))).thenReturn(List.of());
 
@@ -127,7 +142,8 @@ class HabitServiceImplTest {
     @Test
     void getHabit_returnsResponseWithTags() {
         Habit existing = habit(3L, "Stretch", "10 min", HabitFrequency.DAILY, null, null);
-        when(habitRepository.findById(3L)).thenReturn(Optional.of(existing));
+        when(currentUserProvider.getCurrentUserId()).thenReturn(100L);
+        when(habitRepository.findByHabitIdAndOwnerUserId(3L, 100L)).thenReturn(Optional.of(existing));
         when(habitTagRepository.findTagNamesByHabitId(3L)).thenReturn(Set.of("Health"));
 
         GetHabitResponse response = habitService.getHabit(3L);
@@ -139,7 +155,8 @@ class HabitServiceImplTest {
 
     @Test
     void getHabit_throwsHabitNotFoundException_whenHabitMissing() {
-        when(habitRepository.findById(99L)).thenReturn(Optional.empty());
+        when(currentUserProvider.getCurrentUserId()).thenReturn(100L);
+        when(habitRepository.findByHabitIdAndOwnerUserId(99L, 100L)).thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> habitService.getHabit(99L))
                 .isInstanceOf(HabitNotFoundException.class)
@@ -148,7 +165,8 @@ class HabitServiceImplTest {
 
     @Test
     void getAllHabits_returnsEmptyList_whenNoHabits() {
-        when(habitRepository.findAll()).thenReturn(List.of());
+        when(currentUserProvider.getCurrentUserId()).thenReturn(100L);
+        when(habitRepository.findAllByOwnerUserId(100L)).thenReturn(List.of());
 
         List<GetHabitResponse> result = habitService.getAllHabits();
 
@@ -161,7 +179,8 @@ class HabitServiceImplTest {
         Habit first = habit(1L, "Run", null, HabitFrequency.DAILY, null, null);
         Habit second = habit(2L, "Read", null, HabitFrequency.DAILY, null, null);
 
-        when(habitRepository.findAll()).thenReturn(List.of(first, second));
+        when(currentUserProvider.getCurrentUserId()).thenReturn(100L);
+        when(habitRepository.findAllByOwnerUserId(100L)).thenReturn(List.of(first, second));
         when(habitTagRepository.findHabitIdAndTagNameByHabitIds(List.of(1L, 2L)))
                 .thenReturn(List.of(
                         new Object[]{1L, "Health"},
@@ -190,7 +209,8 @@ class HabitServiceImplTest {
                 null
         );
 
-        when(habitRepository.findById(5L)).thenReturn(Optional.of(existing));
+        when(currentUserProvider.getCurrentUserId()).thenReturn(100L);
+        when(habitRepository.findByHabitIdAndOwnerUserId(5L, 100L)).thenReturn(Optional.of(existing));
         when(habitTagRepository.findTagNamesByHabitId(5L)).thenReturn(Set.of("UpdatedTag"));
 
         GetHabitResponse result = habitService.updateHabit(request, 5L);
@@ -215,7 +235,8 @@ class HabitServiceImplTest {
                 List.of("Focus")
         );
 
-        when(habitRepository.findById(6L)).thenReturn(Optional.of(existing));
+        when(currentUserProvider.getCurrentUserId()).thenReturn(100L);
+        when(habitRepository.findByHabitIdAndOwnerUserId(6L, 100L)).thenReturn(Optional.of(existing));
 
         assertThatThrownBy(() -> habitService.updateHabit(request, 6L))
                 .isInstanceOf(InvalidRequestException.class)
@@ -227,7 +248,8 @@ class HabitServiceImplTest {
     @Test
     void deleteHabit_deletesTagLinksThenHabit() {
         Habit existing = habit(7L, "Meditate", null, HabitFrequency.DAILY, null, null);
-        when(habitRepository.findById(7L)).thenReturn(Optional.of(existing));
+        when(currentUserProvider.getCurrentUserId()).thenReturn(100L);
+        when(habitRepository.findByHabitIdAndOwnerUserId(7L, 100L)).thenReturn(Optional.of(existing));
 
         habitService.deleteHabit(7L);
 
@@ -240,7 +262,8 @@ class HabitServiceImplTest {
     void updateTags_returnsImmediately_whenRequestedTagNamesIsNull() {
         habitService.updateTags(8L, null);
 
-        verify(habitRepository, never()).findById(anyLong());
+        verify(currentUserProvider, never()).getCurrentUserId();
+        verify(habitRepository, never()).findByHabitIdAndOwnerUserId(anyLong(), anyLong());
         verify(tagService, never()).getOrCreateEntities(anyCollection());
         verify(habitTagRepository, never()).findTagNamesByHabitId(anyLong());
     }
@@ -251,7 +274,8 @@ class HabitServiceImplTest {
         Tag health = tag(20L, "Health", "health");
         Tag focus = tag(21L, "Focus", "focus");
 
-        when(habitRepository.findById(8L)).thenReturn(Optional.of(existing));
+        when(currentUserProvider.getCurrentUserId()).thenReturn(100L);
+        when(habitRepository.findByHabitIdAndOwnerUserId(8L, 100L)).thenReturn(Optional.of(existing));
         when(tagService.getOrCreateEntities(List.of("Health", "Focus"))).thenReturn(List.of(health, focus));
         when(habitTagRepository.findTagNamesByHabitId(8L)).thenReturn(Set.of("Health", "OldTag"));
 
@@ -320,6 +344,15 @@ class HabitServiceImplTest {
                 .tagId(id)
                 .name(name)
                 .normalizedName(normalizedName)
+                .build();
+    }
+
+    private User user(Long userId, String email) {
+        return User.builder()
+                .userId(userId)
+                .email(email)
+                .password("encoded")
+                .nickname("owner")
                 .build();
     }
 }


### PR DESCRIPTION
## 📌 인증 인가 구현

### ✅ PR 설명

인증 인가 구현

### 🏗 작업 내용

- [ ] User 엔티티 추가
- [ ] Habit, HabitLog userId 연결
- [ ] JWT accessToken 기반 인증, SpringSecurity 필터 적용
- [ ] 사용자 소유 데이터만 조회하도록 변경

### 📸 테스트 결과 (선택)

> 기능을 테스트한 스크린샷이나 실행 결과를 첨부해주세요.

### 🔗 관련 이슈 (선택)

> close #28 

### 🚨 참고 사항 (선택)

> 리뷰어가 참고해야 할 사항이 있다면 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 이메일/비밀번호 인증과 JWT 기반 로그인·토큰 갱신 API 추가
  * 리프레시 토큰 생성·저장·교체 및 해시 처리, JWT 인증 필터와 보안 설정(무상태 세션·비인가 경로 허용) 도입
  * 사용자 계정 엔티티 추가

* **개선 사항**
  * 습관 및 기록 조회/수정/삭제가 소유자 기준으로만 동작하도록 권한 강화
  * 인증·권한 오류(401/403)에 대한 일관된 JSON 응답 추가

* **테스트**
  * 인증·권한 실패 시나리오(401/403) 단위테스트 보강 및 관련 테스트 설정 업데이트
<!-- end of auto-generated comment: release notes by coderabbit.ai -->